### PR TITLE
Enable Google Maps with provided API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ npm install
 
 ## Running locally
 
-Replace `YOUR_API_KEY` in `public/index.html` with a [Google Maps API key](https://developers.google.com/maps/documentation/javascript/get-api-key). Then start the server:
+
+The repository is configured with a demo Google Maps API key in `public/index.html`.
+You can replace it with your own [Google Maps API key](https://developers.google.com/maps/documentation/javascript/get-api-key)
+if desired. Start the server with:
 
 
 ```bash

--- a/public/app.js
+++ b/public/app.js
@@ -2,10 +2,7 @@ var app = angular.module('TaxiFinderApp', []);
 app.controller('MapCtrl', function($scope, $http, $interval) {
   var map = new google.maps.Map(document.getElementById('map'), {
     center: { lat: -33.9249, lng: 18.4241 },
-    zoom: 12,
-    styles: [{ elementType: 'geometry', stylers: [{ color: '#000000' }] },
-             { elementType: 'labels.text.fill', stylers: [{ color: '#d4af37' }] },
-             { elementType: 'labels.text.stroke', stylers: [{ color: '#000000' }] }]
+    zoom: 12
   });
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>iTaxi Finder</title>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.2/angular.min.js"></script>
-    <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCYxFkL9vcvbaFz-Ut1Lm2Vge5byodujfk"></script>
 
   <style>
     body { background: #000; color: #fff; font-family: sans-serif; }


### PR DESCRIPTION
## Summary
- Embed provided Google Maps JavaScript API key in index.html
- Clarify README instructions about demo API key and server startup
- Remove dark map style so base map features are visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd59d4e2ec832e8793bc8dbb84a23b