### PR TITLE
Enable Google Maps with provided API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,25 @@ npm start
 
 This serves the web site at `http://localhost:3000`.
 
-To persist taxi locations, set the environment variable `MONGODB_URI` to a running MongoDB instance before starting the server.
+To persist taxi locations, set the environment variable `MONGODB_URI` to your MongoDB connection string before starting the server.
+
+Examples:
+
+- **macOS/Linux**
+
+  ```bash
+  export MONGODB_URI="mongodb://localhost:27017/taxi"
+  npm start
+  ```
+
+- **Windows (PowerShell)**
+
+  ```powershell
+  $env:MONGODB_URI="mongodb://localhost:27017/taxi"
+  npm start
+  ```
+
+Use the URI of a MongoDB server you control. For a local database, the string above creates/uses a database named `taxi` on `localhost`. For hosted services like [MongoDB Atlas](https://www.mongodb.com/cloud/atlas), obtain the connection string from your dashboard's **Connect** button and substitute it for the examples above.
 
 ### Acting as a taxi
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ npm install
 
 ## Running locally
 
-Replace `YOUR_API_KEY` in `public/index.html` with a [Google Maps API key](https://developers.google.com/maps/documentation/javascript/get-api-key). Then start the server:
+
+The repository is configured with a demo Google Maps API key in `public/index.html`.
+You can replace it with your own [Google Maps API key](https://developers.google.com/maps/documentation/javascript/get-api-key)
+if desired. Start the server with:
 
 
 ```bash
@@ -34,9 +37,11 @@ Open `http://localhost:3000/taxi.html` on a phone (connected to the same network
 
 Navigate to `http://localhost:3000` in a browser to view the map with routes. Click a route to see fare, hand signals, stops and time information.
 
-### Adding custom routes
+### Editing and adding routes
 
-Routes are stored in `data/routes.json`. To add a route without editing files, send a POST request:
+Routes are stored in `data/routes.json`. To change an existing route, edit this file directly and adjust fields such as `stops`, `fare` or the `path` array of `[lat, lng]` points. Refresh the browser (or restart the server) to see the changes.
+
+To add a brand new route without touching files, send a POST request:
 
 ```bash
 curl -X POST http://localhost:3000/api/routes \
@@ -45,6 +50,16 @@ curl -X POST http://localhost:3000/api/routes \
 ```
 
 Newly added routes are appended to `data/routes.json` and appear on the map after a refresh.
+
+### Snapping routes to roads
+
+The app draws coordinates exactly as provided. To align a path with streets, generate coordinates using the [Directions API](https://developers.google.com/maps/documentation/directions/get-directions) or the [Roads API Snap to Roads](https://developers.google.com/maps/documentation/roads/snap) endpoint and use the returned points in your route:
+
+```bash
+curl 'https://roads.googleapis.com/v1/snapToRoads?path=-33.9,18.4|-33.91,18.41&key=YOUR_API_KEY'
+```
+
+Replace `YOUR_API_KEY` with a valid Maps API key, then copy the snapped latitude/longitude pairs into the `path` array in `data/routes.json` or your POST payload.
 
 ## Notes
 

--- a/public/app.js
+++ b/public/app.js
@@ -2,10 +2,7 @@ var app = angular.module('TaxiFinderApp', []);
 app.controller('MapCtrl', function($scope, $http, $interval) {
   var map = new google.maps.Map(document.getElementById('map'), {
     center: { lat: -33.9249, lng: 18.4241 },
-    zoom: 12,
-    styles: [{ elementType: 'geometry', stylers: [{ color: '#000000' }] },
-             { elementType: 'labels.text.fill', stylers: [{ color: '#d4af37' }] },
-             { elementType: 'labels.text.stroke', stylers: [{ color: '#000000' }] }]
+    zoom: 12
   });
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>iTaxi Finder</title>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.2/angular.min.js"></script>
-    <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCYxFkL9vcvbaFz-Ut1Lm2Vge5byodujfk"></script>
 
   <style>
     body { background: #000; color: #fff; font-family: sans-serif; }


### PR DESCRIPTION
## Summary
- Embed provided Google Maps JavaScript API key in index.html
- Clarify README instructions about demo API key and server startup
- Remove dark map style so base map features are visible
- Document how to edit/add routes and use Maps APIs to snap paths to roads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd59d4e2ec832e8793bc8dbb84a23b